### PR TITLE
feat: link the `libdeflate` static library in build script

### DIFF
--- a/bb/build.rs
+++ b/bb/build.rs
@@ -66,6 +66,9 @@ fn main() {
     // Link the `barretenberg` static library.
     println!("cargo:rustc-link-lib=static=barretenberg");
 
+    // Link the `libdeflate` static library.
+    println!("cargo:rustc-link-lib=static=deflate");
+
     // Link the C++ standard library.
     if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
         println!("cargo:rustc-link-lib=c++");


### PR DESCRIPTION
- together with the patch on https://github.com/zkmopro/aztec-packages/commit/57a4b3cd5daa87c5b11a7b236738c50e1368c05c , this PR fix #21 