### PR TITLE
fix: correct import in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ use noir::{
     barretenberg::{
         prove::prove_ultra_honk_keccak,
         srs::{setup_srs_from_bytecode, setup_srs},
-        utils::get_ultra_honk_keccak_verification_key,
+        verify::get_ultra_honk_keccak_verification_key,
         verify::verify_ultra_honk_keccak,
     },
     witness::from_vec_str_to_witness_map,


### PR DESCRIPTION
It seems the function `get_ultra_honk_keccak_verification_key` was moved from `utils` to `verify`

also I suggest adding doctest integration 