### PR TITLE
chore: update noir to v1.0.0-beta.11

### DIFF
--- a/noir/Cargo.toml
+++ b/noir/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "noir"
-version = "1.0.0-beta.8-3"
+version = "1.0.0-beta.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acir = { git = "https://github.com/noir-lang/noir.git", rev = "b33131574388d836341cea9b6380f3b1a8493eb8" }
-acvm = { git = "https://github.com/noir-lang/noir.git", rev = "b33131574388d836341cea9b6380f3b1a8493eb8" }
-acvm_blackbox_solver = { git = "https://github.com/noir-lang/noir.git", rev = "b33131574388d836341cea9b6380f3b1a8493eb8" }
+acir = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.11" }
+acvm = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.11" }
+acvm_blackbox_solver = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.11" }
 base64 = "0.22.0"
-bincode = "1.3.3"
-bn254_blackbox_solver = { git = "https://github.com/noir-lang/noir.git", rev = "b33131574388d836341cea9b6380f3b1a8493eb8" }
-flate2 = "1.0.28"
+bincode = "1.3"
+bn254_blackbox_solver = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.11" }
+flate2 = "1.1"
 hex = "0.4.3"
-nargo = { git = "https://github.com/noir-lang/noir.git", rev = "b33131574388d836341cea9b6380f3b1a8493eb8" }
-reqwest = { version = "0.12.1", default-features = false, features = [
+nargo = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.11" }
+reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
     "blocking",
 ] }
-serde = "1.0.197"
+serde = "1.0"
 thiserror = "1.0.58"
 tracing = "0.1"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
- switched from the rev based reference in cargo to the tag based one. 
- up noir version to beta.11