### PR TITLE
docs: refresh README for noir v1.0.0-beta.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,18 @@
 ```toml
 # Cargo.toml
 [dependencies]
-noir = { git = "https://github.com/zkmopro/noir-rs", features = ["barretenberg"] }
-
-# For Android add the `android-compat` feature:
-noir = { git = "https://github.com/zkmopro/noir-rs", features = ["barretenberg", "android-compat"] }
+noir = { git = "https://github.com/zkmopro/noir-rs", features = ["barretenberg"], tag = "v1.0.0-beta.19" }
 ```
 
 ## Platform Support
 
-For details, please check released artifacts in [zkmopro/aztec-packages](https://github.com/zkmopro/aztec-packages/releases)
+The Barretenberg backend is fetched transitively via the [`barretenberg-rs`](https://crates.io/crates/barretenberg-rs) crate.
 - macOS
     - `aarch64-apple-darwin`
     - `x86_64-apple-darwin`
 - iOS
     - `aarch64‑apple‑ios`
     - `aarch64-apple-ios-sim`
-    - `x86_64-apple-ios`
 - Android
     - `aarch64‑linux‑android`
     - `x86_64-linux-android`


### PR DESCRIPTION
## Summary

Brings the README in line with the post-#37 reality.

- Cargo install snippet pins to immutable tag `v1.0.0-beta.19` and drops the obsolete `android-compat` feature variant (the feature was renamed to `android-build` in #37, and consumers don't need to opt into it explicitly).
- Replaces the `zkmopro/aztec-packages` releases link with a pointer to the [`barretenberg-rs`](https://crates.io/crates/barretenberg-rs) crate, which is now the source of truth for prebuilt FFI binaries.
- Drops `x86_64-apple-ios` from the platform list (no prebuilt barretenberg-rs binaries; CI no longer exercises it).

## Test plan

- [x] `cargo check --features barretenberg` from the `noir/` workspace member.
- [x] Re-rendered README on GitHub; SRS deep-link `#downloading-srs-structured-reference-string` still resolves (heading at line 154 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)